### PR TITLE
Fix for babel parsing compatibility

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,25 +8,24 @@ if (global._asyncHook) {
   // In case the version match, we can simply return the first initialized copy
   if (global._asyncHook.version === require('./package.json').version) {
     module.exports = global._asyncHook;
-    return;
   }
   // The version don't match, this is really bad. Lets just throw
   else {
     throw new Error('Conflicting version of async-hook-jl found');
   }
-}
+} else {
+  const stackChain = require('stack-chain');
 
-const stackChain = require('stack-chain');
-
-// Remove callSites from this module. AsyncWrap doesn't have any callSites
-// and the hooks are expected to be completely transparent.
-stackChain.filter.attach(function (error, frames) {
-  return frames.filter(function (callSite) {
-    const filename = callSite.getFileName();
-    // filename is not always a string, for example in case of eval it is
-    // undefined. So check if the filename is defined.
-    return !(filename && filename.slice(0, __dirname.length) === __dirname);
+  // Remove callSites from this module. AsyncWrap doesn't have any callSites
+  // and the hooks are expected to be completely transparent.
+  stackChain.filter.attach(function (error, frames) {
+    return frames.filter(function (callSite) {
+      const filename = callSite.getFileName();
+      // filename is not always a string, for example in case of eval it is
+      // undefined. So check if the filename is defined.
+      return !(filename && filename.slice(0, __dirname.length) === __dirname);
+    });
   });
-});
 
-module.exports = global._asyncHook = new AsyncHook();
+  module.exports = global._asyncHook = new AsyncHook();
+}


### PR DESCRIPTION
Top-level "return" are not allow in ECMAScript modules, and Babel's
parser will throw when it encounters it.

The use case here is a server app which is using bundling and I need to include the `cls-hooked` module. I have a forked version of `cls-hooked` at https://github.com/bwhitty/cls-hooked which has this fix included (+ pulls in this module directly into the `cls-hooked` package) and it's running fine. Figured I'd upstream this fix.

I've tried to get it to 100% test passing, but these appear to fail on master as well.
```
$ yarn run test
yarn run v0.27.5
$ node ./test/runner.js && eslint .
 - running test-conflict-match.js ... ok
 - running test-conflict-mismatch.js ... ok
 - running test-fsaccess-disabled.js ... ok
 - running test-fsaccess-enabled.js ...
assert.js:81
  throw new assert.AssertionError({
  ^
AssertionError: 1 == NaN
    at process.g (events.js:292:16)
    at emitOne (events.js:96:13)
    at process.emit (events.js:188:7)
 - failed
 - running test-hooks-remove.js ...
assert.js:81
  throw new assert.AssertionError({
  ^
AssertionError: 0 == 1
    at process.g (events.js:292:16)
    at emitOne (events.js:96:13)
    at process.emit (events.js:188:7)
 - failed
 - running test-hooks-twice.js ...
assert.js:81
  throw new assert.AssertionError({
  ^
AssertionError: 0 == 2
    at process.g (events.js:292:16)
    at emitOne (events.js:96:13)
    at process.emit (events.js:188:7)
 - failed
 - running test-immediate-clear-in-callback.js ... ok
 - running test-immediate-clear.js ... ok
 - running test-immediate-didthrow.js ... ok
 - running test-immediate-disabled.js ... ok
 - running test-immediate-enabled.js ... ok
 - running test-immediate-exception.js ... ok
 - running test-immediate-non-function.js ... ok
 - running test-interval-clear-in-callback.js ... ok
 - running test-interval-clear.js ... ok
 - running test-interval-didthrow.js ... ok
 - running test-interval-disabled.js ... ok
 - running test-interval-enabled.js ... ok
 - running test-interval-exception.js ... ok
 - running test-interval-non-function.js ... ok
 - running test-nexttick-didthrow.js ... ok
 - running test-nexttick-disabled.js ... ok
 - running test-nexttick-enabled.js ... ok
 - running test-nexttick-exception.js ... ok
 - running test-nexttick-non-function.js ... ok
 - running test-parent.js ... ok
 - running test-promise-catch-enabled.js ... ok
 - running test-promise-catch-then-chain-fulfilled-enabled.js ... ok
 - running test-promise-disabled.js ... ok
 - running test-promise-then-catch-chain-rejected-enabled.js ... ok
 - running test-promise-then-fulfilled-chained-enabled.js ... ok
 - running test-promise-then-fulfilled-enabled.js ... ok
 - running test-promise-then-fulfilled-multiple-enabled.js ... ok
 - running test-promise-then-rejected-enabled.js ... ok
 - running test-promise-timing.js ... ok
 - running test-stackfilter-eval.js ... ok


  1 Fix for babel parsing compatibility
 - running test-timeout-clear-in-callback.js ... ok
 - running test-timeout-clear.js ... ok
 - running test-timeout-didthrow.js ... ok
 - running test-timeout-disabled.js ... ok
 - running test-timeout-enabled.js ... ok
 - running test-timeout-exception.js ... ok
 - running test-timeout-non-function.js ... ok
failed - 3 tests failed
Done in 6.77s.
```